### PR TITLE
feat: DocumentManager를 통한 이미지 저장/불러오기/삭제 구현

### DIFF
--- a/FilmMark.xcodeproj/project.pbxproj
+++ b/FilmMark.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		E0AACA402CB8C163004A3552 /* MyFilm.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0AACA3F2CB8C163004A3552 /* MyFilm.swift */; };
 		E0AACA422CB8C1F4004A3552 /* MyFilmRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0AACA412CB8C1F4004A3552 /* MyFilmRepository.swift */; };
 		E0AACA6C2CB92B57004A3552 /* LikeAlertViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0AACA6B2CB92B57004A3552 /* LikeAlertViewController.swift */; };
+		E0AACA6E2CB9377A004A3552 /* DocumentManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0AACA6D2CB9377A004A3552 /* DocumentManager.swift */; };
 		E0C45D282CB52BAC00E94B31 /* RealmSwift in Frameworks */ = {isa = PBXBuildFile; productRef = E0C45D272CB52BAC00E94B31 /* RealmSwift */; };
 		E0C45D2B2CB52BBC00E94B31 /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = E0C45D2A2CB52BBC00E94B31 /* SnapKit */; };
 		E0C45D2E2CB52BD500E94B31 /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = E0C45D2D2CB52BD500E94B31 /* Kingfisher */; };
@@ -71,6 +72,7 @@
 		E0AACA3F2CB8C163004A3552 /* MyFilm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyFilm.swift; sourceTree = "<group>"; };
 		E0AACA412CB8C1F4004A3552 /* MyFilmRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyFilmRepository.swift; sourceTree = "<group>"; };
 		E0AACA6B2CB92B57004A3552 /* LikeAlertViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LikeAlertViewController.swift; sourceTree = "<group>"; };
+		E0AACA6D2CB9377A004A3552 /* DocumentManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentManager.swift; sourceTree = "<group>"; };
 		E0C45D332CB52CD100E94B31 /* Colors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Colors.swift; sourceTree = "<group>"; };
 		E0C45D352CB52D1000E94B31 /* Icons.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Icons.swift; sourceTree = "<group>"; };
 		E0C45D372CB52D8100E94B31 /* Fonts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Fonts.swift; sourceTree = "<group>"; };
@@ -179,6 +181,7 @@
 			children = (
 				E0AACA3F2CB8C163004A3552 /* MyFilm.swift */,
 				E0AACA412CB8C1F4004A3552 /* MyFilmRepository.swift */,
+				E0AACA6D2CB9377A004A3552 /* DocumentManager.swift */,
 			);
 			path = Database;
 			sourceTree = "<group>";
@@ -283,6 +286,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				E0C45D8A2CB62FCB00E94B31 /* TargetType.swift in Sources */,
+				E0AACA6E2CB9377A004A3552 /* DocumentManager.swift in Sources */,
 				483BAF0D2CB52591007DABFA /* ViewController.swift in Sources */,
 				487C4A922CB8300F004AA413 /* MyFilmViewController.swift in Sources */,
 				487C4AC72CB914CB004AA413 /* HomeViewModel.swift in Sources */,

--- a/FilmMark/Database/DocumentManager.swift
+++ b/FilmMark/Database/DocumentManager.swift
@@ -1,0 +1,93 @@
+//
+//  DocumentManager.swift
+//  FilmMark
+//
+//  Created by 김정윤 on 10/11/24.
+//
+
+import UIKit
+
+final class DocumentManager {
+    private init() { }
+    static let shared = DocumentManager()
+    private let fileManager = FileManager.default
+    
+    // MARK: 폴더 경로 얻기
+    func getFolderPath() -> URL? {
+        // 폴더 경로 유효한지 확인
+        guard let documentDirectory = fileManager.urls(for: .documentDirectory, in: .userDomainMask).first else { return nil }
+        let folderDirectory = documentDirectory.appendingPathComponent("FilmMark")
+        return folderDirectory
+    }
+    
+    // MARK: 폴더 생성
+    func createFolder() {
+        guard let folderPath = getFolderPath() else { return }
+        if !fileManager.fileExists(atPath: folderPath.path) {
+            do {
+                try fileManager.createDirectory(at: folderPath, withIntermediateDirectories: true)
+            } catch {
+                print("failed to create folder")
+            }
+        } else {
+            return
+        }
+    }
+    
+    // MARK: 이미지 저장
+    func saveImage(imageName: String, image: UIImage) {
+        guard let folderPath = getFolderPath() else { return }
+        createFolder()
+        
+        // 이미지 데이터 불러오기
+        guard let data = image.jpegData(compressionQuality: 0.8) else { return }
+        let imageName = "\(imageName).jpg"
+        let fileURL = folderPath.appendingPathComponent(imageName, conformingTo: .jpeg)
+        
+        // 이미지 저장
+        do {
+            try data.write(to: fileURL)
+        } catch {
+            print("image save error")
+        }
+    }
+    
+    // MARK: 이미지 불러오기
+    func loadImage(imageName: String) -> UIImage? {
+        guard let folderPath = getFolderPath() else {
+            return nil
+        }
+        
+        let imageName = "\(imageName).jpg"
+        let fileURL = folderPath.appendingPathComponent(imageName, conformingTo: .jpeg)
+        
+        // 이미지 있을 경우 이미지 보내고 아니면 다 nil
+        if fileManager.fileExists(atPath: fileURL.path) {
+            guard let result =  UIImage(contentsOfFile: fileURL.path) else {
+                return nil
+            }
+            return result
+        } else {
+            return nil
+        }
+    }
+    
+    // MARK: 이미지 삭제
+    func removeImage(imageName: String) {
+        guard let folderPath = getFolderPath() else { return }
+        
+        let imageName = "\(imageName).jpg"
+        let fileURL = folderPath.appendingPathComponent(imageName, conformingTo: .jpeg)
+        
+        if fileManager.fileExists(atPath: fileURL.path) {
+            do {
+                try fileManager.removeItem(atPath: fileURL.path)
+            } catch {
+                print("file remove error", error)
+            }
+            
+        } else {
+            print("file no exist")
+        }
+    }
+}


### PR DESCRIPTION
- Document 내 통해 FilmMark 폴더를 생성할 수 있어요!
- FileManager를 활용해 이미지를 저장하고 불러오기 또는 삭제할 수 있어요!
- .path()가 iOS16부터 이용가능해서 path로 변경했는데, 폴더 생성까지는 문제가 없는걸 확인했지만 이미지 부분은 아직 실험해볼 수 있는 환경이 안돼서 확인하지 못했습니다.. 혹시 이후에 사용하실 때, 문제가 발생한다면 공유 부탁드릴게요 :)