### PR TITLE
fix: MediaDetailView 내 저장 시 이미지 저장 안되던 문제 해결 / 저장한 데이터 삭제 시 이미지까지 삭제되도록 구현

### DIFF
--- a/FilmMark/MediaDetail/MediaDetailViewModel.swift
+++ b/FilmMark/MediaDetail/MediaDetailViewModel.swift
@@ -48,11 +48,16 @@ class MediaDetailViewModel {
         input.myFilm
             .compactMap { $0 }
             .subscribe(with: self) { owner, value in
+                print(value)
                 let results = SectionOfData(header: "상세뷰", items: [Content(id: -1, backdropPath: nil, title: nil, name: nil, overview: nil, posterPath: nil, genreIds: nil, popularity: nil, video: nil, releaseDate: nil, voteAverage: nil, voteCount: nil, mediaType: nil)])
                 similarContent.accept([results])
             }
             .disposed(by: disposeBag)
         
         return Output(similarContent: similarContent, showAlert: showAlert)
+    }
+    
+    func contentToFilm(_ content: Content) -> MyFilm {
+        return MyFilm(id: content.id, title: content.displayTitle, video: content.video, mediaType: content.mediaType, overview: content.overview, voteAverage: content.formattedVoteAverage)
     }
 }

--- a/FilmMark/MyFilm/MyFilmViewModel.swift
+++ b/FilmMark/MyFilm/MyFilmViewModel.swift
@@ -9,6 +9,7 @@ import Foundation
 import RealmSwift
 
 class MyFilmViewModel {
+    private let fileManager = DocumentManager.shared
     private let realm = try! Realm()
     private(set) var films: Results<MyFilm>?
     
@@ -26,6 +27,8 @@ class MyFilmViewModel {
     
     func deleteFilm(at index: Int) {
         guard let film = films?[index] else { return }
+        fileManager.removeImage(imageName: "\(film.id)_poster")
+        fileManager.removeImage(imageName: "\(film.id)_backdrop")
         do {
             try realm.write {
                 realm.delete(film)


### PR DESCRIPTION
- 상세보기에서 이미지 저장 안되던 문제를 해결했어요!
- 저장한 데이터를 삭제할 때 이미지까지 삭제하도록 처리했어요!